### PR TITLE
Update head-formatter.js

### DIFF
--- a/lib/formatters/head-formatter.js
+++ b/lib/formatters/head-formatter.js
@@ -56,7 +56,7 @@ module.exports = function formatHead (record, config, chalk) {
 
   message = message.split(Constants.NEW_LINE)
 
-  message = message.map(white)
+  message = message.map(msg => white(msg))
 
   const head = [
     color(name),


### PR DESCRIPTION
I'm seeing some weird behavior where my messages get output twice. For example, when trying to log out "Starting server" I instead see "Starting server 0 Starting server". Looks like `messages.map(white)` is the problem. It is the equivalent of writing `messages.map((item, index, array) => white(item, index, array))` where instead we just want to be colorizing the item.